### PR TITLE
Us4

### DIFF
--- a/src/main/java/com/catchapp/api/UserResource.java
+++ b/src/main/java/com/catchapp/api/UserResource.java
@@ -1,0 +1,48 @@
+package com.catchapp.api;
+
+import com.catchapp.api.dto.PasswordChangeRequest;
+import com.catchapp.api.dto.PasswordChangeResponse;
+import com.catchapp.security.JwtSecured;
+import com.catchapp.service.UserService;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
+
+@Path("/users")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class UserResource {
+
+    @Inject
+    UserService userService;
+
+    @POST
+    @Path("/password")
+    @JwtSecured
+    public Response changePassword(
+            @Valid PasswordChangeRequest req,
+            @Context SecurityContext securityContext
+            ) {
+        String username = (securityContext.getUserPrincipal() != null)
+                ? securityContext.getUserPrincipal().getName()
+                : null;
+
+        if (username == null || username.isBlank()) {
+            return Response.status(Response.Status.UNAUTHORIZED)
+                    .entity(new PasswordChangeResponse("Missing or invalid token"))
+                    .build();
+        }
+
+        userService.changePassword(username, req.getOldPassword(), req.getNewPassword());
+        return Response.ok(new PasswordChangeResponse("Password changed successfully")).build();
+    }
+
+
+}

--- a/src/main/java/com/catchapp/api/dto/PasswordChangeRequest.java
+++ b/src/main/java/com/catchapp/api/dto/PasswordChangeRequest.java
@@ -1,0 +1,20 @@
+package com.catchapp.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class PasswordChangeRequest {
+
+    @NotBlank(message = "Old password is required")
+    private String oldPassword;
+
+    @NotBlank(message = "New password is required")
+    @Size(min = 6, message = "New password must be at least 6 characters")
+    private String newPassword;
+
+    public String getOldPassword() { return oldPassword; }
+    public void setOldPassword(String oldPassword) { this.oldPassword = oldPassword; }
+
+    public String getNewPassword() { return newPassword; }
+    public void setNewPassword(String newPassword) { this.newPassword = newPassword; }
+}

--- a/src/main/java/com/catchapp/api/dto/PasswordChangeResponse.java
+++ b/src/main/java/com/catchapp/api/dto/PasswordChangeResponse.java
@@ -1,0 +1,12 @@
+package com.catchapp.api.dto;
+
+public class PasswordChangeResponse {
+    private String message;
+
+    public PasswordChangeResponse(String message) {
+        this.message = message;
+    }
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/catchapp/model/User.java
+++ b/src/main/java/com/catchapp/model/User.java
@@ -64,4 +64,6 @@ public class User {
     public String getEmail() { return email; }
     public String getPasswordHash() { return passwordHash; }
     public Instant getCreatedAt() { return createdAt; }
+
+    public void setPasswordHash(String passwordHash) { this.passwordHash = passwordHash; }
 }

--- a/src/main/java/com/catchapp/service/UserService.java
+++ b/src/main/java/com/catchapp/service/UserService.java
@@ -48,4 +48,27 @@ public User authenticate(String username, String rawPassword) {
         return user;
     }
 
+    public void changePassword(String username, String oldPassword, String newPassword) {
+        var userOpt = userRepository.findByUsername(username);
+        if (userOpt.isEmpty()) throw new IllegalArgumentException("User not found");
+
+        User user = userOpt.get();
+
+        if (!BCrypt.checkpw(oldPassword, user.getPasswordHash())) {
+            throw new IllegalArgumentException("Incorrect current password");
+        }
+
+        String newHash = BCrypt.hashpw(newPassword, BCrypt.gensalt());
+
+        User updated = User.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .passwordHash(newHash)
+                .createdAt(user.getCreatedAt())
+                .build();
+
+        userRepository.save(updated);
+    }
+
 }

--- a/src/main/java/com/catchapp/service/UserService.java
+++ b/src/main/java/com/catchapp/service/UserService.java
@@ -50,7 +50,9 @@ public User authenticate(String username, String rawPassword) {
 
     public void changePassword(String username, String oldPassword, String newPassword) {
         var userOpt = userRepository.findByUsername(username);
-        if (userOpt.isEmpty()) throw new IllegalArgumentException("User not found");
+        if (userOpt.isEmpty()) {
+            throw new IllegalArgumentException("User not found");
+        }
 
         User user = userOpt.get();
 
@@ -59,16 +61,10 @@ public User authenticate(String username, String rawPassword) {
         }
 
         String newHash = BCrypt.hashpw(newPassword, BCrypt.gensalt());
+        user.setPasswordHash(newHash);
 
-        User updated = User.builder()
-                .id(user.getId())
-                .username(user.getUsername())
-                .email(user.getEmail())
-                .passwordHash(newHash)
-                .createdAt(user.getCreatedAt())
-                .build();
-
-        userRepository.save(updated);
+        userRepository.save(user);
     }
+
 
 }

--- a/src/test/java/com/catchapp/api/UserResourceTest.java
+++ b/src/test/java/com/catchapp/api/UserResourceTest.java
@@ -1,4 +1,51 @@
 package com.catchapp.api;
 
+import com.catchapp.api.dto.PasswordChangeRequest;
+import com.catchapp.api.dto.PasswordChangeResponse;
+import com.catchapp.service.UserService;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.*;
+
 public class UserResourceTest {
+
+    private UserService userService;
+    private UserResource userResource;
+    private SecurityContext securityContext;
+    private Principal principal;
+
+    @BeforeEach
+    void setUp() {
+        userService = mock(UserService.class);
+        userResource = new UserResource();
+        userResource.userService = userService;
+        securityContext = mock(SecurityContext.class);
+        principal = mock(Principal.class);
+    }
+
+    @Test
+    void shouldChangePasswordWhenValidRequest() {
+
+        PasswordChangeRequest req = new PasswordChangeRequest();
+        req.setOldPassword("oldpass123");
+        req.setNewPassword("newpass456");
+
+        when(securityContext.getUserPrincipal()).thenReturn(principal);
+        when(principal.getName()).thenReturn("testuser");
+
+        Response response = userResource.changePassword(req, securityContext);
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        assertThat(response.getEntity()).isInstanceOf(PasswordChangeResponse.class);
+        PasswordChangeResponse body = (PasswordChangeResponse) response.getEntity();
+        assertThat(body.getMessage()).isEqualTo("Password changed successfully");
+
+        verify(userService).changePassword("testuser", "oldpass123", "newpass456");
+    }
 }

--- a/src/test/java/com/catchapp/api/UserResourceTest.java
+++ b/src/test/java/com/catchapp/api/UserResourceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import java.security.Principal;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 public class UserResourceTest {
@@ -47,5 +48,47 @@ public class UserResourceTest {
         assertThat(body.getMessage()).isEqualTo("Password changed successfully");
 
         verify(userService).changePassword("testuser", "oldpass123", "newpass456");
+    }
+
+    @Test
+    void shouldFailWhenOldPasswordIncorrect() {
+
+        PasswordChangeRequest req = new PasswordChangeRequest();
+        req.setOldPassword("wrongOld");
+        req.setNewPassword("newpass456");
+
+        when(securityContext.getUserPrincipal()).thenReturn(principal);
+        when(principal.getName()).thenReturn("testuser");
+
+        doThrow(new IllegalArgumentException("Incorrect current password"))
+                .when(userService).changePassword(anyString(), anyString(), anyString());
+
+        IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> userResource.changePassword(req, securityContext)
+        );
+
+        assertThat(thrown.getMessage()).isEqualTo("Incorrect current password");
+        verify(userService).changePassword("testuser", "wrongOld", "newpass456");
+    }
+    @Test
+    void shouldFailWhenMissingOrInvalidToken() {
+
+        PasswordChangeRequest req = new PasswordChangeRequest();
+        req.setOldPassword("oldpass123");
+        req.setNewPassword("newpass456");
+
+        when(securityContext.getUserPrincipal()).thenReturn(null);
+
+
+        Response response = userResource.changePassword(req, securityContext);
+
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.UNAUTHORIZED.getStatusCode());
+        assertThat(response.getEntity()).isInstanceOf(PasswordChangeResponse.class);
+        PasswordChangeResponse body = (PasswordChangeResponse) response.getEntity();
+        assertThat(body.getMessage()).isEqualTo("Missing or invalid token");
+
+        verify(userService, never()).changePassword(anyString(), anyString(), anyString());
     }
 }

--- a/src/test/java/com/catchapp/api/UserResourceTest.java
+++ b/src/test/java/com/catchapp/api/UserResourceTest.java
@@ -1,0 +1,4 @@
+package com.catchapp.api;
+
+public class UserResourceTest {
+}

--- a/src/test/java/com/catchapp/service/UserServiceTest.java
+++ b/src/test/java/com/catchapp/service/UserServiceTest.java
@@ -175,5 +175,25 @@ public class UserServiceTest {
         assertThat(BCrypt.checkpw(newPassword, user.getPasswordHash())).isTrue();
     }
 
+    @Test
+    void shouldFailWhenOldPasswordIncorrect() {
+        String username = "alex"; // Existing user
+        String oldPassword = "wrongpass"; // Incorrect current password
+        String correctHash = BCrypt.hashpw("rightpass", BCrypt.gensalt()); // Correct password hash
 
+        User user = User.builder()
+                .username(username)
+                .passwordHash(correctHash)
+                .build();
+
+        when(userRepository.findByUsername(username)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() ->
+                userService.changePassword(username, oldPassword, "newpass123")
+        )
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Incorrect current password");
+
+        verify(userRepository, never()).save(any());
+    }
 }

--- a/src/test/java/com/catchapp/service/UserServiceTest.java
+++ b/src/test/java/com/catchapp/service/UserServiceTest.java
@@ -155,7 +155,25 @@ public class UserServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Invalid username or password");
     }
+    @Test
+    void changePasswordShouldUpdateWhenOldPasswordCorrect() {
+        String username = "alex";
+        String oldPassword = "oldpass123";
+        String newPassword = "newpass456";
 
+        User user = User.builder()
+                .username(username)
+                .passwordHash(BCrypt.hashpw(oldPassword, BCrypt.gensalt()))
+                .build();
+
+        when(userRepository.findByUsername(username)).thenReturn(Optional.of(user));
+
+        userService.changePassword(username, oldPassword, newPassword);
+
+        verify(userRepository).findByUsername(username);
+        verify(userRepository).save(user);
+        assertThat(BCrypt.checkpw(newPassword, user.getPasswordHash())).isTrue();
+    }
 
 
 }

--- a/src/test/java/com/catchapp/service/UserServiceTest.java
+++ b/src/test/java/com/catchapp/service/UserServiceTest.java
@@ -157,4 +157,5 @@ public class UserServiceTest {
     }
 
 
+
 }


### PR DESCRIPTION
# Pull request for US4

Som användare vill jag kunna ändra mitt lösenord så att jag kan skydda mitt konto.

## Beskrivning

Implementerar stöd för att byta lösenord via backend.
Endpointen är skyddad med JWT och använder det inloggade användarnamnet från token istället för att ange id i URL:en.
Detta är en säkrare och modernare lösning jämfört med den ursprungliga designen. Därav ny API url.

## Tekniska uppgifter

- Endpoint (uppdaterad):

- POST /api/users/password


## Förändringar

- Användaren måste vara inloggad (JWT krävs).

- Gamla lösenordet verifieras.

- Det nya lösenordet hashas med BCrypt och sparas.

- Returnerar: { "message": "Password changed successfully" }