### PR TITLE
US5 - Visa aktiviteter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
             <artifactId>jackson-annotations</artifactId>
             <version>2.16.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -113,8 +113,8 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.17.0</version>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/src/main/java/com/catchapp/api/ActivityResource.java
+++ b/src/main/java/com/catchapp/api/ActivityResource.java
@@ -1,0 +1,26 @@
+package com.catchapp.api;
+
+import com.catchapp.model.Activity;
+import com.catchapp.service.ActivityService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.List;
+
+@Path("/activities")
+@Produces(MediaType.APPLICATION_JSON)
+public class ActivityResource {
+
+    @Inject
+    ActivityService activityService;
+
+    @GET
+    public Response listActivities() {
+        List<Activity> activities = activityService.listActivities();
+        return Response.ok(activities).build();
+    }
+}

--- a/src/main/java/com/catchapp/config/JacksonConfig.java
+++ b/src/main/java/com/catchapp/config/JacksonConfig.java
@@ -1,0 +1,26 @@
+package com.catchapp.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.ext.ContextResolver;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+@Produces("application/json")
+public class JacksonConfig implements ContextResolver<ObjectMapper> {
+
+    private final ObjectMapper mapper;
+
+    public JacksonConfig() {
+        mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    @Override
+    public ObjectMapper getContext(Class<?> type) {
+        return mapper;
+    }
+}

--- a/src/main/java/com/catchapp/model/Activity.java
+++ b/src/main/java/com/catchapp/model/Activity.java
@@ -1,0 +1,56 @@
+package com.catchapp.model;
+
+import java.time.LocalDate;
+
+public class Activity {
+    private Long id;
+    private String title;
+    private String description;
+    private LocalDate date;
+    private String location;
+    private String imageUrl;
+
+    public Activity() {}
+
+    private Activity(Builder builder) {
+        this.id = builder.id;
+        this.title = builder.title;
+        this.description = builder.description;
+        this.date = builder.date;
+        this.location = builder.location;
+        this.imageUrl = builder.imageUrl;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long id;
+        private String title;
+        private String description;
+        private LocalDate date;
+        private String location;
+        private String imageUrl;
+
+        public Builder id(Long id) { this.id = id; return this; }
+        public Builder title(String title) { this.title = title; return this; }
+        public Builder description(String description) { this.description = description; return this; }
+        public Builder date(LocalDate date) { this.date = date; return this; }
+        public Builder location(String location) { this.location = location; return this; }
+        public Builder imageUrl(String imageUrl) { this.imageUrl = imageUrl; return this; }
+
+        public Activity build() {
+            return new Activity(this);
+        }
+    }
+
+    public Long getId() { return id; }
+    public String getTitle() { return title; }
+    public String getDescription() { return description; }
+    public LocalDate getDate() { return date; }
+    public String getLocation() { return location; }
+    public String getImageUrl() { return imageUrl; }
+
+    public void setId(Long id) { this.id = id; }
+}

--- a/src/main/java/com/catchapp/repository/ActivityRepository.java
+++ b/src/main/java/com/catchapp/repository/ActivityRepository.java
@@ -1,0 +1,12 @@
+package com.catchapp.repository;
+
+import com.catchapp.model.Activity;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ActivityRepository {
+    List<Activity> findAll();
+    Optional<Activity> findById(Long id);
+    Activity save(Activity activity);
+}

--- a/src/main/java/com/catchapp/repository/InMemoryActivityRepository.java
+++ b/src/main/java/com/catchapp/repository/InMemoryActivityRepository.java
@@ -1,0 +1,74 @@
+package com.catchapp.repository;
+
+import com.catchapp.model.Activity;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class InMemoryActivityRepository implements ActivityRepository {
+
+    private final Map<Long, Activity> activities = new ConcurrentHashMap<>();
+    private final AtomicLong idGenerator = new AtomicLong();
+
+    public InMemoryActivityRepository() {
+        // Data for development and testing purposes
+
+        save(Activity.builder()
+                .title("Filmkväll")
+                .description("Se film med vänner")
+                .date(LocalDate.now().plusDays(1))
+                .location("Luleå")
+                .imageUrl("film.jpg")
+                .build());
+
+        save(Activity.builder()
+                .title("Löpning i parken")
+                .description("5 km med lokalgrupp")
+                .date(LocalDate.now().plusDays(2))
+                .location("Piteå")
+                .imageUrl("run.jpg")
+                .build());
+
+        save(Activity.builder()
+                .title("Brädspelskväll")
+                .description("Klassiska spel och fika")
+                .date(LocalDate.now().plusDays(3))
+                .location("Boden")
+                .imageUrl("boardgames.jpg")
+                .build());
+    }
+
+    @Override
+    public List<Activity> findAll() {
+        return new ArrayList<>(activities.values());
+    }
+
+    @Override
+    public Optional<Activity> findById(Long id) {
+        return Optional.ofNullable(activities.get(id));
+    }
+
+    @Override
+    public Activity save(Activity activity) {
+        Long id = (activity.getId() != null)
+                ? activity.getId()
+                : idGenerator.getAndIncrement();
+
+        Activity toSave = Activity.builder()
+                .id(id)
+                .title(activity.getTitle())
+                .description(activity.getDescription())
+                .date(activity.getDate())
+                .location(activity.getLocation())
+                .imageUrl(activity.getImageUrl())
+                .build();
+
+        activities.put(id, toSave);
+        return toSave;
+    }
+}

--- a/src/main/java/com/catchapp/repository/InMemoryActivityRepository.java
+++ b/src/main/java/com/catchapp/repository/InMemoryActivityRepository.java
@@ -1,6 +1,7 @@
 package com.catchapp.repository;
 
 import com.catchapp.model.Activity;
+import jakarta.enterprise.context.ApplicationScoped;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -10,6 +11,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
+@ApplicationScoped
 public class InMemoryActivityRepository implements ActivityRepository {
 
     private final Map<Long, Activity> activities = new ConcurrentHashMap<>();

--- a/src/main/java/com/catchapp/repository/InMemoryActivityRepository.java
+++ b/src/main/java/com/catchapp/repository/InMemoryActivityRepository.java
@@ -3,7 +3,6 @@ package com.catchapp.repository;
 import com.catchapp.model.Activity;
 import jakarta.enterprise.context.ApplicationScoped;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -20,29 +19,29 @@ public class InMemoryActivityRepository implements ActivityRepository {
     public InMemoryActivityRepository() {
         // Data for development and testing purposes
 
-        save(Activity.builder()
-                .title("Filmkväll")
-                .description("Se film med vänner")
-                .date(LocalDate.now().plusDays(1))
-                .location("Luleå")
-                .imageUrl("film.jpg")
-                .build());
-
-        save(Activity.builder()
-                .title("Löpning i parken")
-                .description("5 km med lokalgrupp")
-                .date(LocalDate.now().plusDays(2))
-                .location("Piteå")
-                .imageUrl("run.jpg")
-                .build());
-
-        save(Activity.builder()
-                .title("Brädspelskväll")
-                .description("Klassiska spel och fika")
-                .date(LocalDate.now().plusDays(3))
-                .location("Boden")
-                .imageUrl("boardgames.jpg")
-                .build());
+//        save(Activity.builder()
+//                .title("Filmkväll")
+//                .description("Se film med vänner")
+//                .date(LocalDate.now().plusDays(1))
+//                .location("Luleå")
+//                .imageUrl("film.jpg")
+//                .build());
+//
+//        save(Activity.builder()
+//                .title("Löpning i parken")
+//                .description("5 km med lokalgrupp")
+//                .date(LocalDate.now().plusDays(2))
+//                .location("Piteå")
+//                .imageUrl("run.jpg")
+//                .build());
+//
+//        save(Activity.builder()
+//                .title("Brädspelskväll")
+//                .description("Klassiska spel och fika")
+//                .date(LocalDate.now().plusDays(3))
+//                .location("Boden")
+//                .imageUrl("boardgames.jpg")
+//                .build());
     }
 
     @Override

--- a/src/main/java/com/catchapp/repository/InMemoryActivityRepository.java
+++ b/src/main/java/com/catchapp/repository/InMemoryActivityRepository.java
@@ -3,6 +3,7 @@ package com.catchapp.repository;
 import com.catchapp.model.Activity;
 import jakarta.enterprise.context.ApplicationScoped;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -19,29 +20,29 @@ public class InMemoryActivityRepository implements ActivityRepository {
     public InMemoryActivityRepository() {
         // Data for development and testing purposes
 
-//        save(Activity.builder()
-//                .title("Filmkväll")
-//                .description("Se film med vänner")
-//                .date(LocalDate.now().plusDays(1))
-//                .location("Luleå")
-//                .imageUrl("film.jpg")
-//                .build());
-//
-//        save(Activity.builder()
-//                .title("Löpning i parken")
-//                .description("5 km med lokalgrupp")
-//                .date(LocalDate.now().plusDays(2))
-//                .location("Piteå")
-//                .imageUrl("run.jpg")
-//                .build());
-//
-//        save(Activity.builder()
-//                .title("Brädspelskväll")
-//                .description("Klassiska spel och fika")
-//                .date(LocalDate.now().plusDays(3))
-//                .location("Boden")
-//                .imageUrl("boardgames.jpg")
-//                .build());
+        save(Activity.builder()
+                .title("Filmkväll")
+                .description("Se film med vänner")
+                .date(LocalDate.now().plusDays(1))
+                .location("Luleå")
+                .imageUrl("film.jpg")
+                .build());
+
+        save(Activity.builder()
+                .title("Löpning i parken")
+                .description("5 km med lokalgrupp")
+                .date(LocalDate.now().plusDays(2))
+                .location("Piteå")
+                .imageUrl("run.jpg")
+                .build());
+
+        save(Activity.builder()
+                .title("Brädspelskväll")
+                .description("Klassiska spel och fika")
+                .date(LocalDate.now().plusDays(3))
+                .location("Boden")
+                .imageUrl("boardgames.jpg")
+                .build());
     }
 
     @Override

--- a/src/main/java/com/catchapp/service/ActivityService.java
+++ b/src/main/java/com/catchapp/service/ActivityService.java
@@ -1,0 +1,28 @@
+package com.catchapp.service;
+
+import com.catchapp.model.Activity;
+import com.catchapp.repository.ActivityRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.List;
+
+@ApplicationScoped
+public class ActivityService {
+
+    @Inject
+    ActivityRepository activityRepository;
+
+    public ActivityService() {}
+    public ActivityService(ActivityRepository repo) {
+        this.activityRepository = repo;
+    }
+    public List<Activity> listActivities() {
+        return activityRepository.findAll();
+    }
+
+    public Activity getActivityById(Long id) {
+        return activityRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Activity not found"));
+    }
+}

--- a/src/test/java/com/catchapp/api/ActivityResourceTest.java
+++ b/src/test/java/com/catchapp/api/ActivityResourceTest.java
@@ -1,0 +1,68 @@
+package com.catchapp.api;
+
+import com.catchapp.model.Activity;
+import com.catchapp.service.ActivityService;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class ActivityResourceTest {
+
+    private ActivityService service;
+    private ActivityResource resource;
+
+    @BeforeEach
+    void setUp() {
+        // mocks the service layer so we only test the REST-endpoint
+        service = mock(ActivityService.class);
+        resource = new ActivityResource();
+        resource.activityService = service; // inject mock manually
+    }
+
+    @Test
+    void listActivitiesShouldReturnOkAndActivities() {
+        // testing that the endpoint returns 200 OK and a list of activities when they exist
+
+        var a1 = Activity.builder().id(1L).title("Filmkväll").date(LocalDate.now()).build();
+        var a2 = Activity.builder().id(2L).title("Löpning").date(LocalDate.now().plusDays(1)).build();
+
+        when(service.listActivities()).thenReturn(List.of(a1, a2));
+
+        Response response = resource.listActivities();
+
+        // Status should be 200 OK
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+
+        // body should be a list with 2 activities
+        List<Activity> body = (List<Activity>) response.getEntity();
+        assertThat(body).hasSize(2);
+        assertThat(body.get(0).getTitle()).isEqualTo("Filmkväll");
+
+        // verify that the service method was called
+        verify(service).listActivities();
+    }
+
+    @Test
+    void listActivitiesShouldReturnOkAndEmptyListWhenNoneExist() {
+        // testing that the endpoint returns 200 OK and an empty list when no activities exist
+
+        when(service.listActivities()).thenReturn(List.of());
+
+        Response response = resource.listActivities();
+
+        // status should be 200 OK
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+
+        // body should be an empty list
+        List<Activity> body = (List<Activity>) response.getEntity();
+        assertThat(body).isEmpty();
+
+        verify(service).listActivities();
+    }
+}

--- a/src/test/java/com/catchapp/service/ActivityServiceTest.java
+++ b/src/test/java/com/catchapp/service/ActivityServiceTest.java
@@ -1,4 +1,93 @@
 package com.catchapp.service;
 
-public class ActivityServiceTest {
+import com.catchapp.model.Activity;
+import com.catchapp.repository.ActivityRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class ActivityServiceTest {
+
+    private ActivityRepository repo;
+    private ActivityService service;
+
+    @BeforeEach
+    void setUp() {
+        // Mock repo so that we can test the service layer in isolation
+        repo = mock(ActivityRepository.class);
+        service = new ActivityService(repo);
+    }
+
+    @Test
+    void listActivitiesShouldReturnAllActivities() {
+        // Testing so all activities are returned correctly
+
+        var a1 = Activity.builder()
+                .id(1L)
+                .title("Filmkväll")
+                .date(LocalDate.now())
+                .build();
+
+        var a2 = Activity.builder()
+                .id(2L)
+                .title("Löpning")
+                .date(LocalDate.now().plusDays(1))
+                .build();
+
+        when(repo.findAll()).thenReturn(List.of(a1, a2));
+
+        List<Activity> result = service.listActivities();
+
+        // verify that the correct data is returned
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getTitle()).isEqualTo("Filmkväll");
+        verify(repo).findAll();
+    }
+
+    @Test
+    void listActivitiesShouldReturnEmptyListWhenNoActivitiesExist() {
+        // testing so an empty list is returned if no activities exist
+
+        when(repo.findAll()).thenReturn(List.of());
+
+        List<Activity> result = service.listActivities();
+
+        // should be empty
+        assertThat(result).isEmpty();
+        verify(repo).findAll();
+    }
+
+    @Test
+    void getActivityByIdShouldReturnActivityWhenFound() {
+        // testing so an activity is returned when it exists
+
+        var a1 = Activity.builder().id(1L).title("Bio").build();
+        when(repo.findById(1L)).thenReturn(Optional.of(a1));
+
+        Activity result = service.getActivityById(1L);
+
+        // activity found and correct
+        assertThat(result).isNotNull();
+        assertThat(result.getTitle()).isEqualTo("Bio");
+        verify(repo).findById(1L);
+    }
+
+    @Test
+    void getActivityByIdShouldThrowWhenNotFound() {
+        // testing so an exception is thrown when the activity does not exist
+
+        when(repo.findById(99L)).thenReturn(Optional.empty());
+
+        // should throw exception
+        assertThatThrownBy(() -> service.getActivityById(99L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Activity not found");
+    }
 }

--- a/src/test/java/com/catchapp/service/ActivityServiceTest.java
+++ b/src/test/java/com/catchapp/service/ActivityServiceTest.java
@@ -1,0 +1,4 @@
+package com.catchapp.service;
+
+public class ActivityServiceTest {
+}


### PR DESCRIPTION
# Pull Request – US5: Visa aktiviteter

## Beskrivning
Denna PR implementerar User Story US5 i CatchApp-backend.
Syftet är att tillhandahålla en endpoint som returnerar en lista över tillgängliga aktiviteter.

## Vad som är gjort

- Skapat Activity-entitet med builder pattern

- Skapat InMemoryActivityRepository för temporär lagring

- Implementerat ActivityService för logik och hantering

- Implementerat ActivityResource (REST endpoint /api/activities)

- Skapat JacksonConfig för korrekt datumserialisering (YYYY-MM-DD)

- Lagt till enhetstester för ActivityService och ActivityResource

- Verifierat JSON-output i Postman

- Tom lista hanteras korrekt ([] + 200 OK)