### PR TITLE
Us5.5

### DIFF
--- a/src/main/java/com/catchapp/api/ActivityResource.java
+++ b/src/main/java/com/catchapp/api/ActivityResource.java
@@ -5,6 +5,7 @@ import com.catchapp.service.ActivityService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -22,5 +23,12 @@ public class ActivityResource {
     public Response listActivities() {
         List<Activity> activities = activityService.listActivities();
         return Response.ok(activities).build();
+    }
+
+    @GET
+    @Path("/{id}")
+    public Response getActivityById(@PathParam("id") Long id) {
+        Activity activity = activityService.getActivityById(id);
+        return Response.ok(activity).build();
     }
 }

--- a/src/main/java/com/catchapp/exception/IllegalArgumentExceptionMapper.java
+++ b/src/main/java/com/catchapp/exception/IllegalArgumentExceptionMapper.java
@@ -5,14 +5,19 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 
-
 @Provider
 public class IllegalArgumentExceptionMapper implements ExceptionMapper<IllegalArgumentException> {
 
     @Override
     public Response toResponse(IllegalArgumentException e) {
-        return Response.status(Response.Status.BAD_REQUEST)
-                .entity(ErrorResponse.of(e.getMessage()))
+        String message = e.getMessage();
+
+        int status = (message != null && message.toLowerCase().contains("not found"))
+                ? Response.Status.NOT_FOUND.getStatusCode()
+                : Response.Status.BAD_REQUEST.getStatusCode();
+
+        return Response.status(status)
+                .entity(ErrorResponse.of(message))
                 .build();
     }
 }

--- a/src/test/java/com/catchapp/service/ActivityServiceTest.java
+++ b/src/test/java/com/catchapp/service/ActivityServiceTest.java
@@ -90,4 +90,37 @@ class ActivityServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Activity not found");
     }
+
+    @Test
+    void shouldReturnListOfActivities() {
+        var a1 = Activity.builder()
+                .id(1L)
+                .title("Filmkväll")
+                .date(LocalDate.now())
+                .build();
+        var a2 = Activity.builder()
+                .id(2L)
+                .title("Spela brädspel")
+                .date(LocalDate.now())
+                .build();
+
+        when(repo.findAll()).thenReturn(List.of(a1, a2));
+
+        var result = service.listActivities();
+
+        assertThat(result).hasSize(2);
+        verify(repo).findAll();
+    }
+
+    @Test
+    void shouldReturnActivityWhenFound() {
+        var a1 = Activity.builder().id(1L).title("Filmkväll").build();
+
+        when(repo.findById(1L)).thenReturn(Optional.of(a1));
+
+        var result = service.getActivityById(1L);
+
+        assertThat(result.getTitle()).isEqualTo("Filmkväll");
+        verify(repo).findById(1L);
+    }
 }

--- a/src/test/java/com/catchapp/service/ActivityServiceTest.java
+++ b/src/test/java/com/catchapp/service/ActivityServiceTest.java
@@ -123,4 +123,15 @@ class ActivityServiceTest {
         assertThat(result.getTitle()).isEqualTo("Filmkväll");
         verify(repo).findById(1L);
     }
+
+    @Test
+    void shouldThrowWhenActivityNotFound() {
+        when(repo.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getActivityById(99L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Activity not found");
+
+        verify(repo).findById(99L);
+    }
 }


### PR DESCRIPTION

# US5.5 – Visa specifik aktivitet

Missade att lägga till detta i US5. Vilket ska vara en del av denna, en miss i planeringen helt enkelt.

## Beskrivning
Lade till endpoint för att hämta en enskild aktivitet baserat på ID.
Implementationen följer befintlig arkitektur med tydlig separering mellan Resource, Service och Repository.
ExceptionMapper används för att hantera 404- och 400-fel utan duplicerad felhantering i resurserna.

## ändringar

- GET /api/activities/{id}  i ActivityResource

- getActivityById() i ActivityService

- Uppdaterat IllegalArgumentExceptionMapper att hantera 404 responses

- lagt till ActivityServiceTest för positiva och negativa utkomster

