### PR TITLE
US6, US7, US8

### DIFF
--- a/src/main/java/com/catchapp/api/ActivityResource.java
+++ b/src/main/java/com/catchapp/api/ActivityResource.java
@@ -1,16 +1,17 @@
 package com.catchapp.api;
 
 import com.catchapp.model.Activity;
+import com.catchapp.security.JwtSecured;
 import com.catchapp.service.ActivityService;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
 
 import java.util.List;
+import java.util.Map;
 
 @Path("/activities")
 @Produces(MediaType.APPLICATION_JSON)
@@ -30,5 +31,14 @@ public class ActivityResource {
     public Response getActivityById(@PathParam("id") Long id) {
         Activity activity = activityService.getActivityById(id);
         return Response.ok(activity).build();
+    }
+
+    @POST
+    @Path("/{id}/like")
+    @JwtSecured
+    public Response likeActivity(@PathParam("id") Long id, @Context SecurityContext context) {
+        String username = context.getUserPrincipal().getName();
+        activityService.likeActivity(username, id);
+        return Response.ok(Map.of("message", "Activity liked")).build();
     }
 }

--- a/src/main/java/com/catchapp/api/ActivityResource.java
+++ b/src/main/java/com/catchapp/api/ActivityResource.java
@@ -41,4 +41,22 @@ public class ActivityResource {
         activityService.likeActivity(username, id);
         return Response.ok(Map.of("message", "Activity liked")).build();
     }
+
+    @DELETE
+    @Path("/{id}/like")
+    @JwtSecured
+    public Response unlikeActivity(@PathParam("id") Long id, @Context SecurityContext context) {
+        String username = context.getUserPrincipal().getName();
+        activityService.unlikeActivity(username, id);
+        return Response.ok(Map.of("message", "Activity unliked")).build();
+    }
+
+    @GET
+    @Path("/favorites")
+    @JwtSecured
+    public Response listFavorites(@Context SecurityContext context) {
+        String username = context.getUserPrincipal().getName();
+        List<Activity> favorites = activityService.listFavorites(username);
+        return Response.ok(favorites).build();
+    }
 }

--- a/src/main/java/com/catchapp/model/Favorite.java
+++ b/src/main/java/com/catchapp/model/Favorite.java
@@ -1,0 +1,10 @@
+package com.catchapp.model;
+
+import java.time.Instant;
+
+public class Favorite {
+    private long id;
+    private Instant createdAt;
+    private User user;
+    private Activity activity;
+}

--- a/src/main/java/com/catchapp/model/Favorite.java
+++ b/src/main/java/com/catchapp/model/Favorite.java
@@ -7,4 +7,35 @@ public class Favorite {
     private Instant createdAt;
     private User user;
     private Activity activity;
+
+    public Favorite() {}
+
+    private Favorite(Builder builder) {
+        this.id = builder.id;
+        this.createdAt = builder.createdAt != null ? builder.createdAt : Instant.now();
+        this.user = builder.user;
+        this.activity = builder.activity;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long id;
+        private Instant createdAt;
+        private User user;
+        private Activity activity;
+
+        public Builder id(Long id) { this.id = id; return this; }
+        public Builder createdAt(Instant createdAt) { this.createdAt = createdAt; return this; }
+        public Builder user(User user) { this.user = user; return this; }
+        public Builder activity(Activity activity) { this.activity = activity; return this; }
+
+        public Favorite build() { return new Favorite(this); }
+    }
+    public Long getId() { return id; }
+    public Instant getCreatedAt() { return createdAt; }
+    public User getUser() { return user; }
+    public Activity getActivity() { return activity; }
 }

--- a/src/main/java/com/catchapp/model/Favorite.java
+++ b/src/main/java/com/catchapp/model/Favorite.java
@@ -3,7 +3,7 @@ package com.catchapp.model;
 import java.time.Instant;
 
 public class Favorite {
-    private long id;
+    private Long id;
     private Instant createdAt;
     private User user;
     private Activity activity;
@@ -17,9 +17,7 @@ public class Favorite {
         this.activity = builder.activity;
     }
 
-    public static Builder builder() {
-        return new Builder();
-    }
+    public static Builder builder() { return new Builder(); }
 
     public static class Builder {
         private Long id;
@@ -34,6 +32,7 @@ public class Favorite {
 
         public Favorite build() { return new Favorite(this); }
     }
+
     public Long getId() { return id; }
     public Instant getCreatedAt() { return createdAt; }
     public User getUser() { return user; }

--- a/src/main/java/com/catchapp/repository/FavoriteRepository.java
+++ b/src/main/java/com/catchapp/repository/FavoriteRepository.java
@@ -1,0 +1,14 @@
+package com.catchapp.repository;
+
+import com.catchapp.model.Activity;
+import com.catchapp.model.Favorite;
+import com.catchapp.model.User;
+
+import java.util.List;
+
+public interface FavoriteRepository {
+    boolean existsByUserAndActivity(User user, Activity activity);
+    Favorite save(Favorite favorite);
+    void deleteByUserAndActivity(User user, Activity activity);
+    List<Activity> findActivitiesByUser(User user);
+}

--- a/src/main/java/com/catchapp/repository/InMemoryFavoriteRepository.java
+++ b/src/main/java/com/catchapp/repository/InMemoryFavoriteRepository.java
@@ -1,0 +1,55 @@
+package com.catchapp.repository;
+
+import com.catchapp.model.Activity;
+import com.catchapp.model.Favorite;
+import com.catchapp.model.User;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class InMemoryFavoriteRepository implements FavoriteRepository {
+
+    private final Map<Long, Favorite> favorites = new ConcurrentHashMap<>();
+    private final AtomicLong idGenerator = new AtomicLong(1);
+
+    @Override
+    public boolean existsByUserAndActivity(User user, Activity activity) {
+        return favorites.values().stream()
+                .anyMatch(f -> f.getUser().getUsername().equals(user.getUsername())
+                        && f.getActivity().getId().equals(activity.getId()));
+    }
+
+    @Override
+    public Favorite save(Favorite favorite) {
+        Long id = favorite.getId() != null ? favorite.getId() : idGenerator.getAndIncrement();
+        Favorite toSave = Favorite.builder()
+                .id(id)
+                .user(favorite.getUser())
+                .activity(favorite.getActivity())
+                .createdAt(favorite.getCreatedAt())
+                .build();
+        favorites.put(id, toSave);
+        return toSave;
+    }
+
+    @Override
+    public void deleteByUserAndActivity(User user, Activity activity) {
+        favorites.entrySet().removeIf(e ->
+                e.getValue().getUser().getUsername().equals(user.getUsername())
+        && e.getValue().getActivity().getId().equals(activity.getId()));
+    }
+
+    @Override
+    public List<Activity> findActivitiesByUser(User user) {
+        return favorites.values().stream()
+                .filter(f -> f.getUser().getUsername().equals(user.getUsername()))
+                .map(Favorite::getActivity)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/catchapp/service/ActivityService.java
+++ b/src/main/java/com/catchapp/service/ActivityService.java
@@ -1,7 +1,10 @@
 package com.catchapp.service;
 
 import com.catchapp.model.Activity;
+import com.catchapp.model.User;
 import com.catchapp.repository.ActivityRepository;
+import com.catchapp.repository.FavoriteRepository;
+import com.catchapp.repository.UserRepository;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -13,9 +16,17 @@ public class ActivityService {
     @Inject
     ActivityRepository activityRepository;
 
+    @Inject
+    FavoriteRepository favoriteRepository;
+
+    @Inject
+    UserRepository userRepository;
+
     public ActivityService() {}
-    public ActivityService(ActivityRepository repo) {
+    public ActivityService(ActivityRepository repo, FavoriteRepository favRepo, UserRepository userRepo) {
         this.activityRepository = repo;
+        this.favoriteRepository = favRepo;
+        this.userRepository = userRepo;
     }
     public List<Activity> listActivities() {
         return activityRepository.findAll();
@@ -24,5 +35,12 @@ public class ActivityService {
     public Activity getActivityById(Long id) {
         return activityRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Activity not found"));
+    }
+
+    public void likeActivity(String username, Long activityId) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new IllegalArgumentException("Activity already liked"));
     }
 }

--- a/src/main/java/com/catchapp/service/ActivityService.java
+++ b/src/main/java/com/catchapp/service/ActivityService.java
@@ -68,4 +68,10 @@ public class ActivityService {
 
         favoriteRepository.deleteByUserAndActivity(user, activity);
     }
+
+    public List<Activity> listFavorites(String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        return favoriteRepository.findActivitiesByUser(user);
+    }
 }

--- a/src/main/java/com/catchapp/service/ActivityService.java
+++ b/src/main/java/com/catchapp/service/ActivityService.java
@@ -55,4 +55,17 @@ public class ActivityService {
 
         favoriteRepository.save(favorite);
     }
+
+    public void unlikeActivity(String username, Long activityId) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new IllegalArgumentException("Activity not found"));
+
+        if (!favoriteRepository.existsByUserAndActivity(user, activity)) {
+            throw new IllegalArgumentException("Activity not liked");
+        }
+
+        favoriteRepository.deleteByUserAndActivity(user, activity);
+    }
 }

--- a/src/main/java/com/catchapp/service/ActivityService.java
+++ b/src/main/java/com/catchapp/service/ActivityService.java
@@ -1,6 +1,7 @@
 package com.catchapp.service;
 
 import com.catchapp.model.Activity;
+import com.catchapp.model.Favorite;
 import com.catchapp.model.User;
 import com.catchapp.repository.ActivityRepository;
 import com.catchapp.repository.FavoriteRepository;
@@ -41,6 +42,17 @@ public class ActivityService {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
         Activity activity = activityRepository.findById(activityId)
-                .orElseThrow(() -> new IllegalArgumentException("Activity already liked"));
+                .orElseThrow(() -> new IllegalArgumentException("Activity not found"));
+
+        if (favoriteRepository.existsByUserAndActivity(user, activity)) {
+            throw new IllegalArgumentException("Activity already liked");
+        }
+
+        Favorite favorite = Favorite.builder()
+                .user(user)
+                .activity(activity)
+                .build();
+
+        favoriteRepository.save(favorite);
     }
 }

--- a/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
+++ b/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
@@ -138,4 +138,16 @@ public class ActivityServiceFavoritesTest {
         verify(favoriteRepo, never()).findActivitiesByUser(any());
     }
 
+    @Test
+    void shouldDeleteFavoriteWhenExists() {
+        // Testing so that a favorite is deleted when it exists
+        when(userRepo.findByUsername("testuser")).thenReturn(Optional.of(user));
+        when(activityRepo.findById(10L)).thenReturn(Optional.of(activity));
+        when(favoriteRepo.existsByUserAndActivity(user, activity)).thenReturn(true);
+
+        service.unlikeActivity("testuser", 10L);
+
+        verify(favoriteRepo).deleteByUserAndActivity(user, activity);
+    }
+
 }

--- a/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
+++ b/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
@@ -150,4 +150,16 @@ public class ActivityServiceFavoritesTest {
         verify(favoriteRepo).deleteByUserAndActivity(user, activity);
     }
 
+    @Test
+    void shouldThrowWhenUserNotFoundOnUnlike() {
+        // should throw an exception if the user does not exist when unliking an activity
+        when(userRepo.findByUsername("ghost")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.unlikeActivity("ghost", 10L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("User not found");
+
+        verify(favoriteRepo, never()).deleteByUserAndActivity(any(), any());
+    }
+
 }

--- a/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
+++ b/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
@@ -115,4 +115,15 @@ public class ActivityServiceFavoritesTest {
         verify(favoriteRepo).findActivitiesByUser(user);
     }
 
+    @Test
+    void shouldReturnEmptyListWhenNoFavoritesExist() {
+        // empty list is returned if the user has no favorite activities
+        when(userRepo.findByUsername("testuser")).thenReturn(Optional.of(user));
+        when(favoriteRepo.findActivitiesByUser(user)).thenReturn(List.of());
+
+        List<Activity> favorites = service.listFavorites("testuser");
+
+        assertThat(favorites).isEmpty();
+    }
+
 }

--- a/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
+++ b/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
@@ -1,0 +1,75 @@
+package com.catchapp.service;
+
+import com.catchapp.model.Activity;
+import com.catchapp.model.Favorite;
+import com.catchapp.model.User;
+import com.catchapp.repository.ActivityRepository;
+import com.catchapp.repository.FavoriteRepository;
+import com.catchapp.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+public class ActivityServiceFavoritesTest {
+
+    private ActivityRepository activityRepo;
+    private FavoriteRepository favoriteRepo;
+    private UserRepository userRepo;
+    private ActivityService service;
+
+    private User user;
+    private Activity activity;
+
+    @BeforeEach
+    void setUp() {
+
+        activityRepo = mock(ActivityRepository.class);
+        favoriteRepo = mock(FavoriteRepository.class);
+        userRepo = mock(UserRepository.class);
+        service = new ActivityService(activityRepo, favoriteRepo, userRepo);
+
+        user = User.builder()
+                .id(1L)
+                .username("testuser")
+                .email("test@example.com")
+                .passwordHash("hash")
+                .build();
+
+        activity = Activity.builder()
+                .id(10L)
+                .title("Träning")
+                .date(LocalDate.now())
+                .build();
+    }
+
+    @Test
+    void shouldSaveFavoriteWhenValidUserLikesActivity() {
+        // Testing so that a favorite is saved when a valid user likes a valid activity
+        when(userRepo.findByUsername("testuser")).thenReturn(Optional.of(user)); // user exists
+        when(activityRepo.findById(10L)).thenReturn(Optional.of(activity)); // activity exists
+        when(favoriteRepo.existsByUserAndActivity(user, activity)).thenReturn(false); // user hasn't liked activity yet
+
+        service.likeActivity("testuser", 10L); // the action being tested
+
+        // verifies that the favorite was saved
+        verify(favoriteRepo).save(any(Favorite.class));
+    }
+
+    @Test
+    void shouldThrowWhenNonExistingUserTriedToLikeActivity() {
+        // testing so that an exception is thrown if the user does not exist
+        when(userRepo.findByUsername("cantbefound")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.likeActivity("cantbefound", 10L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("User not found");
+
+        verify(favoriteRepo, never()).save(any());
+    }
+
+}

--- a/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
+++ b/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
@@ -162,4 +162,17 @@ public class ActivityServiceFavoritesTest {
         verify(favoriteRepo, never()).deleteByUserAndActivity(any(), any());
     }
 
+    @Test
+    void shouldThrowWhenActivityNotFoundOnUnlike() {
+        // should throw an exception if the activity does not exist when unliking
+        when(userRepo.findByUsername("testuser")).thenReturn(Optional.of(user));
+        when(activityRepo.findById(10L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.unlikeActivity("testuser", 10L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Activity not found");
+
+        verify(favoriteRepo, never()).deleteByUserAndActivity(any(), any());
+    }
+
 }

--- a/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
+++ b/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
@@ -72,4 +72,17 @@ public class ActivityServiceFavoritesTest {
         verify(favoriteRepo, never()).save(any());
     }
 
+    @Test
+    void shouldThrowWhenActivityNotFoundOnLike() {
+        // testing so that an exception is thrown if the activity does not exist
+        when(userRepo.findByUsername("testuser")).thenReturn(Optional.of(user));
+        when(activityRepo.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.likeActivity("testuser", 99L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Activity not found");
+
+        verify(favoriteRepo, never()).save(any());
+    }
+
 }

--- a/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
+++ b/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
@@ -85,4 +85,18 @@ public class ActivityServiceFavoritesTest {
         verify(favoriteRepo, never()).save(any());
     }
 
+    @Test
+    void shouldThrowWhenActivityAlreadyLiked() {
+        // testing so that an exception is thrown if the activity has already been liked by the user
+        when(userRepo.findByUsername("testuser")).thenReturn(Optional.of(user));
+        when(activityRepo.findById(10L)).thenReturn(Optional.of(activity));
+        when(favoriteRepo.existsByUserAndActivity(user, activity)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.likeActivity("testuser", 10L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Activity already liked");
+
+        verify(favoriteRepo, never()).save(any());
+    }
+
 }

--- a/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
+++ b/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
@@ -10,9 +10,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.Mockito.*;
 
 public class ActivityServiceFavoritesTest {
@@ -97,6 +99,20 @@ public class ActivityServiceFavoritesTest {
                 .hasMessage("Activity already liked");
 
         verify(favoriteRepo, never()).save(any());
+    }
+
+    @Test
+    void shouldReturnFavoritesForUser() {
+        // Testing so that the correct list of favorite activities is returned for a user
+        when(userRepo.findByUsername("testuser")).thenReturn(Optional.of(user));
+        when(favoriteRepo.findActivitiesByUser(user)).thenReturn(List.of(activity));
+
+        List<Activity> favorites = service.listFavorites("testuser");
+
+        // verifies that the returned list is correct
+        assertThat(favorites).hasSize(1);
+        assertThat(favorites.get(0).getTitle()).isEqualTo("Träning");
+        verify(favoriteRepo).findActivitiesByUser(user);
     }
 
 }

--- a/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
+++ b/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
@@ -102,7 +102,7 @@ public class ActivityServiceFavoritesTest {
     }
 
     @Test
-    void shouldReturnFavoritesForUser() {
+    void shouldReturnFavoritesWhenUserHasLikedActivities() {
         // Testing so that the correct list of favorite activities is returned for a user
         when(userRepo.findByUsername("testuser")).thenReturn(Optional.of(user));
         when(favoriteRepo.findActivitiesByUser(user)).thenReturn(List.of(activity));
@@ -151,7 +151,7 @@ public class ActivityServiceFavoritesTest {
     }
 
     @Test
-    void shouldThrowWhenUserNotFoundOnUnlike() {
+    void shouldThrowWhenNotFoundOnUnlike() {
         // should throw an exception if the user does not exist when unliking an activity
         when(userRepo.findByUsername("ghost")).thenReturn(Optional.empty());
 
@@ -171,6 +171,20 @@ public class ActivityServiceFavoritesTest {
         assertThatThrownBy(() -> service.unlikeActivity("testuser", 10L))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Activity not found");
+
+        verify(favoriteRepo, never()).deleteByUserAndActivity(any(), any());
+    }
+
+    @Test
+    void shouldThrowWhenUserTriesToUnlikeActivityNotLiked() {
+        // should throw an exception if the activity was not previously liked by the user
+        when(userRepo.findByUsername("testuser")).thenReturn(Optional.of(user));
+        when(activityRepo.findById(10L)).thenReturn(Optional.of(activity));
+        when(favoriteRepo.existsByUserAndActivity(user, activity)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.unlikeActivity("testuser", 10L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Activity not liked");
 
         verify(favoriteRepo, never()).deleteByUserAndActivity(any(), any());
     }

--- a/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
+++ b/src/test/java/com/catchapp/service/ActivityServiceFavoritesTest.java
@@ -126,4 +126,16 @@ public class ActivityServiceFavoritesTest {
         assertThat(favorites).isEmpty();
     }
 
+    @Test
+    void shouldThrowWhenUserNotFoundOnListFavorites() {
+        // should throw an exception if the user does not exist when listing favorites
+        when(userRepo.findByUsername("ghost")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.listFavorites("ghost"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("User not found");
+
+        verify(favoriteRepo, never()).findActivitiesByUser(any());
+    }
+
 }

--- a/src/test/java/com/catchapp/service/ActivityServiceTest.java
+++ b/src/test/java/com/catchapp/service/ActivityServiceTest.java
@@ -2,6 +2,8 @@ package com.catchapp.service;
 
 import com.catchapp.model.Activity;
 import com.catchapp.repository.ActivityRepository;
+import com.catchapp.repository.FavoriteRepository;
+import com.catchapp.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +24,9 @@ class ActivityServiceTest {
     void setUp() {
         // Mock repo so that we can test the service layer in isolation
         repo = mock(ActivityRepository.class);
-        service = new ActivityService(repo);
+        var favRepo = mock(FavoriteRepository.class);
+        var userRepo = mock(UserRepository.class);
+        service = new ActivityService(repo, favRepo, userRepo);
     }
 
     @Test


### PR DESCRIPTION
# Pull Request – Favoritfunktionalitet (US6–US8)

## Innehåll

Denna PR och dess issues var tajt sammankopplade, och har arbetat med tillsammans. Den innehåller alltså 3 US. US 6, 7, 8.

## Sammanfattning

Den här pull requesten implementerar hela favoritflödet för aktiviteter i CatchApp. Användare kan nu gilla, visa och ta bort gillade aktiviteter.

## Innehåll


**US6 – Gilla aktivitet**

- Användare kan gilla (spara) en aktivitet.
- Ny endpoint: POST /api/activities/{id}/like
- Lagrar relationen mellan användare och aktivitet i en Favorite-entitet.
- Validerar att användaren och aktiviteten existerar.
- Förhindrar dubbletter (en användare kan inte gilla samma aktivitet flera gånger).
-Returnerar: { "message": "Activity liked" }

**US7 – Visa favoriter**

- Användare kan hämta sina sparade aktiviteter.
- Ny endpoint: GET /api/activities/favorites
- Skyddad med JWT-autentisering.
- Returnerar en lista av användarens favoritaktiviteter:
[
  { "id": 1, "title": "Filmkväll", "description": "...", "date": "2025-10-09", "location": "Luleå" }
]

**US8 – Ta bort gilla**

- Användare kan ta bort (ogilla) en aktivitet de tidigare gillat.
- Ny endpoint: DELETE /api/activities/{id}/like
- Kontrollerar att aktiviteten är gillad innan borttagning.
- Returnerar: { "message": "Activity unliked" }

## Tekniska ändringar

- Ny modell: Favorite
- Nytt repository: FavoriteRepository + InMemoryFavoriteRepository
- Utökad ActivityService med:
- likeActivity(String username, Long activityId)
- unlikeActivity(String username, Long activityId)
- listFavorites(String username)
- Utökad ActivityResource med nya endpoints för gilla, ogilla och lista favoriter.
- Säkerhet: samtliga nya endpoints skyddade med @JwtSecured.
- Uppdaterade InMemory-repositories används tills JPA/Docker införs.

## Tester

Tester har lagts till för att täcka samtliga 3 User Stories.
